### PR TITLE
Add executable docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.7
+
+RUN wget https://github.com/svenstaro/genact/releases/download/0.2.2/genact-linux -O /tmp/genact-linux
+RUN chmod +x /tmp/genact-linux
+ENTRYPOINT ["/tmp/genact-linux"]


### PR DESCRIPTION
To solve issue #9. This here is instructions for docker.

### Build docker image
```
$ docker build . -t svenstaro/genact
```

Image is based on `genact 0.2.2` and `apline` for image base.  
See `Dockerfile` for details.

By the way, this wget
```
RUN wget https://github.com/svenstaro/genact/releases/download/0.2.2/genact-linux -O /tmp/genact-linux
```
can be swap to this if you have local executables
```
COPY genact-linux /tmp
```

### Run

```
$ docker run -t svenstaro/genact
```

For specify modules, type:

```
$ docker run -t svenstaro/genact -m cc
```

### Stop

1. Hit `control + P` and `control + Q` at Mac to detach current tty.  
(It may various by different OS)

Note that use `control + C` also works but contrainer will still running.

2. Find out the container id that genact runs.

	```
	$ docker ps
	CONTAINER ID        IMAGE               COMMAND               CREATED             STATUS              PORTS               NAMES
	d5a9b3742975        svenstaro/genact    "/tmp/genact-linux"   2 seconds ago       Up 2 seconds                            eager_tesla
	```	

3. Stop that container

	```
	$ docker kill d5a9b3742975
	```
