### PR TITLE
Fix: Separate mtune from include path in cc module

### DIFF
--- a/src/cc.rs
+++ b/src/cc.rs
@@ -108,7 +108,7 @@ pub fn run() {
 
     // Compile everything.
     for cfile in &chosen_files {
-        println!("{compiler} -c {opt} {warn}{f}{arch}{includes}{defs} -o {output_file}",
+        println!("{compiler} -c {opt} {warn}{f}{arch} {includes}{defs} -o {output_file}",
                  compiler=compiler,
                  opt=opt,
                  warn=warn_final,


### PR DESCRIPTION
The `-mtune` flag(arch in code) and the include path are stitched together.
This fixes a "compilation issue" :)

Before:
```
-fPIC-Iarch/mips/cavium-octeon/crypto
```
After:
```
-fPIC -mtune=generic -Iarch/sparc/kernel
```