### PR TITLE
use multistage Dockerfile to keep image size low

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM rust as builder
 
-ENV APP_HOME /usr/src/app
+ENV APP_HOME /usr/src/app/
 
-RUN mkdir -p $APP_HOME
+RUN rustup target add x86_64-unknown-linux-musl
+RUN apt-get update && apt-get install -y upx
+
+COPY . $APP_HOME
 WORKDIR $APP_HOME
+RUN make build-linux
 
-ADD . $APP_HOME
-
-RUN ["cargo", "build", "--release"]
-
-FROM bitnami/minideb
-COPY --from=builder /usr/src/app/target/release/genact /app/
+FROM scratch
+COPY --from=builder /usr/src/app/target/x86_64-unknown-linux-musl/release/genact /app/
 ENTRYPOINT ["/app/genact"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust
+FROM rust as builder
 
 ENV APP_HOME /usr/src/app
 
@@ -9,4 +9,6 @@ ADD . $APP_HOME
 
 RUN ["cargo", "build", "--release"]
 
-ENTRYPOINT ["./target/release/genact"]
+FROM bitnami/minideb
+COPY --from=builder /usr/src/app/target/release/genact /app/
+ENTRYPOINT ["/app/genact"]


### PR DESCRIPTION
I added some lines to the Dockerfile to utilize multi-stage builds. This reduces the image size to around ~60MB by only adding the final `genact` binary to the image.