### PR TITLE
Fix blemish where incorrect arch would be printed

### DIFF
--- a/src/kernel_compile.rs
+++ b/src/kernel_compile.rs
@@ -178,7 +178,7 @@ pub fn run(appconfig: &AppConfig) {
 
     println!("CRC {:x}", crc);
 
-    println!("Kernel: arch/x86/boot/bzImage is ready (#1)");
+    println!("Kernel: arch/{}/boot/bzImage is ready (#1)", arch);
 
     println!();
 }


### PR DESCRIPTION
_Someone_ forgot to print the correct architecture upon completion of the compilation. This commit fixes that.