### PR TITLE
Add burst mode to bootlog module

### DIFF
--- a/src/bootlog.rs
+++ b/src/bootlog.rs
@@ -9,10 +9,24 @@ use BOOTLOG_LIST;
 pub fn run(appconfig: &AppConfig) {
     let mut rng = thread_rng();
     let num_lines = rng.gen_range(50, 200);
+    let mut burst_mode = false;
+    let mut count_burst_lines = 0;
 
     for _ in 1..num_lines {
         let choice = rng.choose(&BOOTLOG_LIST).unwrap_or(&"");
-        let sleep_length = rng.gen_range(10, 1000);
+        let mut line_sleep_length = rng.gen_range(10, 1000);
+        let mut char_sleep_length = 5;
+        let burst_lines = rng.gen_range(10, 50);
+
+        if burst_mode && count_burst_lines < burst_lines {
+            line_sleep_length = 30;
+            char_sleep_length = 0;
+        } else if count_burst_lines == burst_lines {
+            burst_mode = false;
+            count_burst_lines = 0;
+        } else if burst_mode == false {
+            burst_mode = rng.gen_weighted_bool(20);
+        }
 
         let is_error = rng.gen_weighted_bool(100);
         if is_error {
@@ -22,14 +36,18 @@ pub fn run(appconfig: &AppConfig) {
             if has_bold_word {
                 let mut words: Vec<String> = choice.split_whitespace().map(String::from).collect();
                 words[0] = format!("{}", Paint::new(&words[0]).bold());
-                dprint(format!("{}", words.join(" ")), 5);
+                dprint(format!("{}", words.join(" ")), char_sleep_length);
             } else {
-                dprint(format!("{}", choice), 5);
+                dprint(format!("{}", choice), char_sleep_length);
             }
         }
 
         println!();
-        csleep(sleep_length);
+        if burst_mode {
+            count_burst_lines += 1;
+        }
+
+        csleep(line_sleep_length);
 
         if appconfig.should_exit() {
             return;


### PR DESCRIPTION
#### What does this PR do?
It adds burst mode to the bootlog module

#### Description of Task to be completed?
* The bootlog module should behave a bit more realistically in that it should sometimes burst a bunch of lines really quickly

#### How should this be manually tested?
* Run `cargo run -- -m bootlog` in the project
* The output should be printed in quick succession from time to time. 