### PR TITLE
Use exp distribution to generate package number for cargo module

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,6 +1,6 @@
 /// Module that pretends to run cargo to install rust packages.
 use rand::prelude::*;
-use rand::distributions::{ChiSquared, Distribution};
+use rand::distributions::{ChiSquared, Distribution, Exp};
 use std::time::Instant;
 use yansi::Paint;
 
@@ -9,10 +9,11 @@ use crate::PACKAGES_LIST;
 use crate::parse_args::AppConfig;
 
 fn gen_package_version(rng: &mut ThreadRng) -> String {
-    let chi = ChiSquared::new(1.0);
+    let chi = ChiSquared::new(1.0); 
+    let exp = Exp::new(2.0);
     format!(
         "{major:.0}.{minor:.0}.{patch:.0}",
-        major = 10.0 * chi.sample(rng),
+        major = exp.sample(rng),
         minor = 10.0 * chi.sample(rng),
         patch = 10.0 * chi.sample(rng)
     )


### PR DESCRIPTION
Hi !

A quick and stupid fix for the `cargo` module, which at the moment creates crazy high major version numbers compared to the actual Rust ecosystem on `crates.io`. Currently, running `genact -m cargo` can give you:
```console
 Downloading tolk-sys v5.19.7
 Downloading parse_torrent v1.2.0
 Downloading fn_mut v25.4.1
 Downloading just v6.9.14
 Downloading crast v4.5.9
 Downloading kdtree v16.26.0
 Downloading error_util v46.84.0
```

With this fix, you get something along the lines of:
```console
Downloading grabbag v0.2.10
 Downloading fwdlist v1.1.1
 Downloading genfsm v0.3.22
 Downloading bvh v0.23.27
 Downloading mocktopus_macros v0.3.3
 Downloading jemallocator v1.7.24
 Downloading boolfuck v0.3.7
 Downloading ipp-sys v0.3.1
 Downloading fux_kdtree v2.7.63
 Downloading char_set v1.29.0
 Downloading xmljson v0.8.0
 Downloading type-level-logic v0.0.3
```

which looks a bit more like normal cargo output !