### PR TITLE
docs(install): add x-cmd method to install genact

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,18 @@ It is also available on Scoop:
 
     scoop install genact
 
+
+
 **With Cargo**: If you have a somewhat recent version of Rust and Cargo installed, you can run
 
     cargo install genact
     genact
+
+**With X-CMD**: If you are an x-cmd user, you can run
+
+    x env use genact
+    genact
+
 
 ## Running
 


### PR DESCRIPTION
- Hi, [x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.. It helps you download genact release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the genact README.md?**[The installation method for the x command](https://www.x-cmd.com/start/).
  ```sh
  x env use genact
  ```

- We wrote a [genact introduction article and a demo](https://www.x-cmd.com/pkg/genact)