### PR TITLE
docs: Add installation method with gah

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ It is also available on Scoop:
     cargo install genact
     genact
 
+**With gah**: If you are using [gah](https://github.com/marverix/gah), you can run
+
+    gah install genact
+
 ## Running
 
 To see a list of all available options, you can run


### PR DESCRIPTION
Hello!
This PR adds to the documentation installation method using [gah](https://github.com/marverix/gah):
> gah is an GitHub Releases app installer, that DOES NOT REQUIRE SUDO! It is a simple bash script that downloads the latest release of an app from GitHub and installs it in ~/.local/bin. It is designed to be used with apps that are distributed as a single binary file.